### PR TITLE
Fix ansible documenation breaking the lookup plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ For example,
             name: thycotic
 ```
 
+For the playbook lookup to work, you need to download and install/extract the Thcotic Secret Server SDK/(CLI) 
+The ``sdk_client_path`` variable defined in "thycotic_sdk_config.yml" should
+point to the directory that contains the tycotic sercret server SDK/CLI.
+The path should contain the file ``tss`` and a bunch of .dll files.
+
 ## Authors
 
 Paulo Dorado

--- a/thycotic_secret.py
+++ b/thycotic_secret.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = """
-      lookup: thycotic_sdk
+        lookup: thycotic_sdk
         author: Paulo Dorado <pdorado@tsiva.com>
         version_added: "1.0"
         short_description: Look up secrets from Thycoptic Secret Server

--- a/thycotic_secret.py
+++ b/thycotic_secret.py
@@ -8,14 +8,13 @@ DOCUMENTATION = """
         version_added: "1.0"
         short_description: Look up secrets from Thycoptic Secret Server
         description:
-            - This lookup uses the Thycotic SDK python library to lookup secrets in
-        options:
-          _terms:
-            description: path(s) of files to read
-            required: True
+          - This lookup uses the Thycotic SDK python library to lookup
+            secrets from a Thycotic Secret Server
         notes:
-          - if read in variable context, the file can be interpreted as YAML if the content is valid to the parser.
-          - this lookup does not understand 'globing' - use the fileglob lookup instead.
+          - This module expects the the sdk client which includes the files
+            'tss' and relevant *.dll files to be present in the path specifed
+            in variable 'sdk_client_path'. This is in addition to installting
+            the python module - secret-server-sdk-client
 """
 
 from ansible.errors import AnsibleError, AnsibleParserError
@@ -34,8 +33,6 @@ class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
         config_dict = variables[kwargs['thycotic_config']]
         result = []
-
-        print(kwargs)
 
         client = SDK_Client()
         client.configure(config_dict['sdk_client_path'],


### PR DESCRIPTION
The pluging does not work in it's original state.
This patch fixes the bug that prevents the lookup plugin from working.
Also adds a few more sentences of dumentation in the module and the readyme file.